### PR TITLE
Inject version number into plugin description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
 # Copyright (c) 2019 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+SHELL=/bin/bash
+# Obtain the version and git commit info
+GIT_VERSION=$(shell git describe --match 'v*' --always)
+
+# Override the value of the version variable in main.go
+LD_FLAGS= '-X main.version=$(GIT_VERSION)'
+GO_FLAGS= -ldflags=$(LD_FLAGS)
+
 ifdef XDG_CONFIG_HOME
 	OCTANT_PLUGINSTUB_DIR ?= ${XDG_CONFIG_HOME}/octant/plugins
 # Determine in on windows
@@ -16,7 +24,7 @@ RECURSIVE_DIRS = $(addsuffix /...,$(DIRS))
 .PHONY: install-plugin
 install-plugin:
 	mkdir -p $(OCTANT_PLUGINSTUB_DIR)
-	go build -o $(OCTANT_PLUGINSTUB_DIR)/airship-ui-plugin opendev.org/airship/airshipui/cmd/airshipui
+	go build -o $(OCTANT_PLUGINSTUB_DIR)/airship-ui-plugin $(GO_FLAGS) opendev.org/airship/airshipui/cmd/airshipui
 
 .PHONY: test
 test: generate

--- a/cmd/airshipui/main.go
+++ b/cmd/airshipui/main.go
@@ -1,19 +1,25 @@
 package main
 
 import (
+    "fmt"
     "log"
     "opendev.org/airship/airshipui/internal/plugin"
 )
 
-var pluginName = "airship-ui"
+var (
+    pluginName = "airship-ui"
+    // version will be overriden by ldflags supplied in Makefile
+    version = "(dev-version)"
+)
 
 // This is a sample plugin showing the features of Octant's plugin API.
 func main() {
     // Remove the prefix from the go logger since Octant will print logs with timestamps.
     log.SetPrefix("")
 
+    description := fmt.Sprintf("Airship UI version %s", version)
     // Use the plugin service helper to register this plugin.
-    p, err := plugin.Register(pluginName, "Airship UI")
+    p, err := plugin.Register(pluginName, description)
     if err != nil {
         log.Fatal(err)
     }


### PR DESCRIPTION
Inject the version number from git into the plugin description, which is displayed in the Octant UI plugin tab.  Note that until the first version is tagged, this value will contain only a git commit hash, and after the first version is tagged it will contain the tag name plus the hash.